### PR TITLE
Edge orders 9-12: Upgrade to 1.0 and adding new API

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -6,6 +6,10 @@
     {
       "id": "gobi",
       "version": "1.0"
+    },
+    {
+      "id": "login",
+      "version": "5.0"
     }
   ],
   "permissionSets": [],

--- a/jmeter/Folio-Test-Plans/edge-orders/validate/edge-ordersValidateTestPlan.jmx
+++ b/jmeter/Folio-Test-Plans/edge-orders/validate/edge-ordersValidateTestPlan.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="4.0" jmeter="4.0 r1823414">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.0 r1840935">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Edge Orders Validate Test Plan" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -13,7 +13,7 @@
     </TestPlan>
     <hashTree>
       <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="FOLIO Login and Host Config" enabled="true">
-        <stringProp name="filename">Folio-Test-Plans/config.csv</stringProp>
+        <stringProp name="filename">/Users/kvuppala/git/edge-orders/jmeter/Folio-Test-Plans/edge-orders/validate/validate.csv</stringProp>
         <stringProp name="fileEncoding">UTF-8</stringProp>
         <stringProp name="variableNames">tenant,user,password,protocol,host,port,apiKey</stringProp>
         <boolProp name="ignoreFirstLine">false</boolProp>
@@ -55,7 +55,7 @@
           <collectionProp name="HeaderManager.headers"/>
         </HeaderManager>
         <hashTree/>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GET (204) Valid" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GET (200) Valid" enabled="true">
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>

--- a/jmeter/Folio-Test-Plans/edge-orders/validate/edge-ordersValidateTestPlan.jmx
+++ b/jmeter/Folio-Test-Plans/edge-orders/validate/edge-ordersValidateTestPlan.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.0 r1840935">
+<jmeterTestPlan version="1.2" properties="4.0" jmeter="4.0 r1823414">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Edge Orders Validate Test Plan" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -13,7 +13,7 @@
     </TestPlan>
     <hashTree>
       <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="FOLIO Login and Host Config" enabled="true">
-        <stringProp name="filename">Folio-Test-Plans/validate.csv</stringProp>
+        <stringProp name="filename">Folio-Test-Plans/config.csv</stringProp>
         <stringProp name="fileEncoding">UTF-8</stringProp>
         <stringProp name="variableNames">tenant,user,password,protocol,host,port,apiKey</stringProp>
         <boolProp name="ignoreFirstLine">false</boolProp>

--- a/jmeter/Folio-Test-Plans/edge-orders/validate/edge-ordersValidateTestPlan.jmx
+++ b/jmeter/Folio-Test-Plans/edge-orders/validate/edge-ordersValidateTestPlan.jmx
@@ -74,9 +74,9 @@
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - 204" enabled="true">
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - 200" enabled="true">
             <collectionProp name="Asserion.test_strings">
-              <stringProp name="49590">204</stringProp>
+              <stringProp name="49590">200</stringProp>
             </collectionProp>
             <stringProp name="Assertion.custom_message"></stringProp>
             <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>

--- a/jmeter/Folio-Test-Plans/edge-orders/validate/edge-ordersValidateTestPlan.jmx
+++ b/jmeter/Folio-Test-Plans/edge-orders/validate/edge-ordersValidateTestPlan.jmx
@@ -13,7 +13,7 @@
     </TestPlan>
     <hashTree>
       <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="FOLIO Login and Host Config" enabled="true">
-        <stringProp name="filename">/Users/kvuppala/git/edge-orders/jmeter/Folio-Test-Plans/edge-orders/validate/validate.csv</stringProp>
+        <stringProp name="filename">Folio-Test-Plans/validate.csv</stringProp>
         <stringProp name="fileEncoding">UTF-8</stringProp>
         <stringProp name="variableNames">tenant,user,password,protocol,host,port,apiKey</stringProp>
         <boolProp name="ignoreFirstLine">false</boolProp>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>1.0.0</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/ramls/edge-orders.raml
+++ b/ramls/edge-orders.raml
@@ -51,7 +51,7 @@ types:
         description: Success
         body:
           application/xml:
-           example: "<test>GET - OK</test>"
+           example: "<test>POST - OK</test>"
        400:
         description: Bad Request
         body:

--- a/ramls/edge-orders.raml
+++ b/ramls/edge-orders.raml
@@ -14,8 +14,11 @@ schemas:
   get:
     description: 'Validate that the API Key provided can be used to place an order'
     responses:
-      '204':
+      '200':
         description: Success
+        body:
+          application/xml:
+          schema: "<test>GET - OK</test>"
       '400':
         description: 'Bad Request'
         body:
@@ -43,6 +46,41 @@ schemas:
       apikey:
         description: 'API Key'
         type: string
+  post:
+    description: 'Validate that the API Key provided can be used to place an order'
+    responses:
+      '200':
+        description: Success
+        body:
+          application/xml:
+          schema: "<test>GET - OK</test>"
+      '400':
+        description: 'Bad Request'
+        body:
+          application/xml:
+            schema: orders
+      '401':
+        description: 'Access Denied'
+        body:
+          application/xml:
+            schema: orders
+      '408':
+        description: 'Request Timeout'
+        body:
+          application/xml:
+            schema: orders
+      '500':
+        description: 'Internal Server Error'
+        body:
+          application/xml:
+            schema: orders
+    queryParameters:
+      type:
+        description: 'purchasing system type'
+        type: string
+      apikey:
+        description: 'API Key'
+        type: string     
 /orders:
   displayName: 'Place Order'
   post:

--- a/ramls/edge-orders.raml
+++ b/ramls/edge-orders.raml
@@ -1,13 +1,11 @@
-#%RAML 0.8
+#%RAML 1.0
 title: 'Edge API - Orders'
 baseUri: 'https://github.com/folio-org/edge-orders'
 version: v1
 documentation:
-  -
     title: 'Edge API - Orders'
     content: 'Edge API to interface with FOLIO for 3rd party purchasing systems for placing orders'
-schemas:
-  -
+types:
     orders: !include orders.xsd
 /orders/validate:
   displayName: Validate
@@ -18,27 +16,27 @@ schemas:
         description: Success
         body:
           application/xml:
-          schema: "<test>GET - OK</test>"
+          type: "<test>GET - OK</test>"
       '400':
         description: 'Bad Request'
         body:
           application/xml:
-            schema: orders
+            type: orders
       '401':
         description: 'Access Denied'
         body:
           application/xml:
-            schema: orders
+            type: orders
       '408':
         description: 'Request Timeout'
         body:
           application/xml:
-            schema: orders
+            type: orders
       '500':
         description: 'Internal Server Error'
         body:
           application/xml:
-            schema: orders
+            type: orders
     queryParameters:
       type:
         description: 'purchasing system type'
@@ -53,27 +51,27 @@ schemas:
         description: Success
         body:
           application/xml:
-          schema: "<test>GET - OK</test>"
+          type: "<test>GET - OK</test>"
       '400':
         description: 'Bad Request'
         body:
           application/xml:
-            schema: orders
+            type: orders
       '401':
         description: 'Access Denied'
         body:
           application/xml:
-            schema: orders
+            type: orders
       '408':
         description: 'Request Timeout'
         body:
           application/xml:
-            schema: orders
+            type: orders
       '500':
         description: 'Internal Server Error'
         body:
           application/xml:
-            schema: orders
+            type: orders
     queryParameters:
       type:
         description: 'purchasing system type'
@@ -90,27 +88,27 @@ schemas:
         description: Success
         body:
           application/xml:
-            schema: orders
+            type: orders
       '400':
         description: 'Bad Request'
         body:
           application/xml:
-            schema: orders
+            type: orders
       '401':
         description: 'Access Denied'
         body:
           application/xml:
-            schema: orders
+            type: orders
       '408':
         description: 'Request Timeout'
         body:
           application/xml:
-            schema: orders
+            type: orders
       '500':
         description: 'Internal Server Error'
         body:
           application/xml:
-            schema: orders
+            type: orders
     queryParameters:
       type:
         description: 'purchasing system type'

--- a/ramls/edge-orders.raml
+++ b/ramls/edge-orders.raml
@@ -1,127 +1,127 @@
 #%RAML 1.0
-title: 'Edge API - Orders'
-baseUri: 'https://github.com/folio-org/edge-orders'
+title: Edge API - Orders
+baseUri: https://github.com/folio-org/edge-orders
 version: v1
 documentation:
-    title: 'Edge API - Orders'
-    content: 'Edge API to interface with FOLIO for 3rd party purchasing systems for placing orders'
+  - title: Edge API - Orders
+    content: Edge API to interface with FOLIO for 3rd party purchasing systems for placing orders
 types:
     orders: !include orders.xsd
 /orders/validate:
   displayName: Validate
   get:
-    description: 'Validate that the API Key provided can be used to place an order'
+    description: Validate that the API Key provided can be used to place an order
     responses:
-      '200':
+       200:
         description: Success
         body:
           application/xml:
-          type: "<test>GET - OK</test>"
-      '400':
-        description: 'Bad Request'
+           example: "<test>GET - OK</test>"
+       400:
+        description: Bad Request
         body:
           application/xml:
             type: orders
-      '401':
-        description: 'Access Denied'
+       401:
+        description: Access Denied
         body:
           application/xml:
             type: orders
-      '408':
-        description: 'Request Timeout'
+       408:
+        description: Request Timeout
         body:
           application/xml:
             type: orders
-      '500':
-        description: 'Internal Server Error'
+       500:
+        description: Internal Server Error
         body:
           application/xml:
             type: orders
     queryParameters:
       type:
-        description: 'purchasing system type'
+        description: purchasing system type
         type: string
       apikey:
-        description: 'API Key'
+        description: API Key
         type: string
   post:
-    description: 'Validate that the API Key provided can be used to place an order'
+    description: Validate that the API Key provided can be used to place an order
     responses:
-      '200':
+       200:
         description: Success
         body:
           application/xml:
-          type: "<test>GET - OK</test>"
-      '400':
-        description: 'Bad Request'
+           example: "<test>GET - OK</test>"
+       400:
+        description: Bad Request
         body:
           application/xml:
             type: orders
-      '401':
-        description: 'Access Denied'
+       401:
+        description: Access Denied
         body:
           application/xml:
             type: orders
-      '408':
-        description: 'Request Timeout'
+       408:
+        description: Request Timeout
         body:
           application/xml:
             type: orders
-      '500':
-        description: 'Internal Server Error'
+       500:
+        description: Internal Server Error
         body:
           application/xml:
             type: orders
     queryParameters:
       type:
-        description: 'purchasing system type'
+        description: purchasing system type
         type: string
       apikey:
-        description: 'API Key'
+        description: API Key
         type: string     
 /orders:
-  displayName: 'Place Order'
+  displayName: Place Order
   post:
-    description: 'Place an order'
+    description: Place an order
     responses:
-      '201':
+       201:
         description: Success
         body:
           application/xml:
             type: orders
-      '400':
-        description: 'Bad Request'
+       400:
+        description: Bad Request
         body:
           application/xml:
             type: orders
-      '401':
-        description: 'Access Denied'
+       401:
+        description: Access Denied
         body:
           application/xml:
             type: orders
-      '408':
-        description: 'Request Timeout'
+       408:
+        description: Request Timeout
         body:
           application/xml:
             type: orders
-      '500':
-        description: 'Internal Server Error'
+       500:
+        description: Internal Server Error
         body:
           application/xml:
             type: orders
     queryParameters:
       type:
-        description: 'purchasing system type'
+        description: purchasing system type
         type: string
       apikey:
-        description: 'API Key'
+        description: API Key
         type: string
 /admin/health:
-  displayName: 'Health Check'
+  displayName: Health Check
   get:
-    description: 'Health Check'
+    description: Health Check
     responses:
-      '200':
+      200:
         description: Success
         body:
           text/plain: null

--- a/src/main/java/org/folio/edge/orders/MainVerticle.java
+++ b/src/main/java/org/folio/edge/orders/MainVerticle.java
@@ -22,8 +22,7 @@ public class MainVerticle extends EdgeVerticle {
     Router router = Router.router(vertx);
     router.route().handler(BodyHandler.create());
     router.route(HttpMethod.GET, "/admin/health").handler(this::handleHealthCheck);
-    router.route(HttpMethod.GET, "/orders/validate").handler(validateHandler::handle);
-    router.route(HttpMethod.POST, "/orders/validate").handler(validateHandler::handle);
+    router.route(HttpMethod.GET, "/orders/validate").method(HttpMethod.POST).handler(validateHandler::handle);
     router.route(HttpMethod.POST, "/orders").handler(ordersHandler::handle);
     return router;
   }

--- a/src/main/java/org/folio/edge/orders/MainVerticle.java
+++ b/src/main/java/org/folio/edge/orders/MainVerticle.java
@@ -2,7 +2,6 @@ package org.folio.edge.orders;
 
 import org.folio.edge.core.EdgeVerticle;
 import org.folio.edge.orders.utils.OrdersOkapiClientFactory;
-
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
@@ -24,6 +23,7 @@ public class MainVerticle extends EdgeVerticle {
     router.route().handler(BodyHandler.create());
     router.route(HttpMethod.GET, "/admin/health").handler(this::handleHealthCheck);
     router.route(HttpMethod.GET, "/orders/validate").handler(validateHandler::handle);
+    router.route(HttpMethod.POST, "/orders/validate").handler(validateHandler::handlePost);
     router.route(HttpMethod.POST, "/orders").handler(ordersHandler::handle);
     return router;
   }

--- a/src/main/java/org/folio/edge/orders/MainVerticle.java
+++ b/src/main/java/org/folio/edge/orders/MainVerticle.java
@@ -23,7 +23,7 @@ public class MainVerticle extends EdgeVerticle {
     router.route().handler(BodyHandler.create());
     router.route(HttpMethod.GET, "/admin/health").handler(this::handleHealthCheck);
     router.route(HttpMethod.GET, "/orders/validate").handler(validateHandler::handle);
-    router.route(HttpMethod.POST, "/orders/validate").handler(validateHandler::handlePost);
+    router.route(HttpMethod.POST, "/orders/validate").handler(validateHandler::handle);
     router.route(HttpMethod.POST, "/orders").handler(ordersHandler::handle);
     return router;
   }

--- a/src/main/java/org/folio/edge/orders/OrdersHandler.java
+++ b/src/main/java/org/folio/edge/orders/OrdersHandler.java
@@ -93,35 +93,38 @@ public class OrdersHandler extends Handler {
       }
 
       body.append(buf);
-    }).endHandler(v -> {
-      ctx.response().setStatusCode(resp.statusCode());
-
-      if (body.length() > 0) {
-        String respBody = body.toString();
-
-        if (logger.isDebugEnabled()) {
-          logger.debug("status: " + resp.statusCode() + " response: " + respBody);
-        }
-
-        try {
-          String xml = StringUtils.EMPTY;
-          if(respBody.contains(VALIDATE_SUCCESS)){
-            xml = respBody;
-          }else {
-            xml = parseResponse(resp, respBody).toXml();
-          }
-
+    })
+        .endHandler(v -> {
           ctx.response()
-            .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_XML)
-            .end(xml);
-        } catch (Exception e) {
-          logger.error("Failed to convert FOLIO response to XML", e);
-          internalServerError(ctx, "Failed to convert FOLIO response to XML");
-        }
-      } else {
-        ctx.response().end();
-      }
-    });
+              .setStatusCode(resp.statusCode());
+
+          if (body.length() > 0) {
+            String respBody = body.toString();
+
+            if (logger.isDebugEnabled()) {
+              logger.debug("status: " + resp.statusCode() + " response: " + respBody);
+            }
+
+            try {
+              String xml = StringUtils.EMPTY;
+              if (respBody.contains(VALIDATE_SUCCESS)) {
+                xml = respBody;
+              } else {
+                xml = parseResponse(resp, respBody).toXml();
+              }
+
+              ctx.response()
+                  .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_XML)
+                  .end(xml);
+            } catch (Exception e) {
+              logger.error("Failed to convert FOLIO response to XML", e);
+              internalServerError(ctx, "Failed to convert FOLIO response to XML");
+            }
+          } else {
+            ctx.response()
+                .end();
+          }
+        });
   }
 
   private ResponseWrapper parseResponse(HttpClientResponse resp, String respBody) throws IOException {

--- a/src/main/java/org/folio/edge/orders/OrdersHandler.java
+++ b/src/main/java/org/folio/edge/orders/OrdersHandler.java
@@ -9,7 +9,7 @@ import static org.folio.edge.orders.Constants.PARAM_TYPE;
 
 import java.io.IOException;
 import java.util.Map;
-
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.folio.edge.core.Handler;
 import org.folio.edge.core.security.SecureStore;
@@ -27,6 +27,7 @@ import io.vertx.ext.web.RoutingContext;
 
 public class OrdersHandler extends Handler {
 
+  private static final String VALIDATE_SUCCESS = "<test>";
   private static final Logger logger = Logger.getLogger(OrdersHandler.class);
 
   public OrdersHandler(SecureStore secureStore, OrdersOkapiClientFactory ocf) {
@@ -103,7 +104,13 @@ public class OrdersHandler extends Handler {
         }
 
         try {
-          String xml = parseResponse(resp, respBody).toXml();
+          String xml = StringUtils.EMPTY;
+          if(respBody.contains(VALIDATE_SUCCESS)){
+            xml = respBody;
+          }else {
+            xml = parseResponse(resp, respBody).toXml();
+          }
+
           ctx.response()
             .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_XML)
             .end(xml);

--- a/src/main/java/org/folio/edge/orders/ValidateHandler.java
+++ b/src/main/java/org/folio/edge/orders/ValidateHandler.java
@@ -7,7 +7,7 @@ import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.orders.Constants.PurchasingSystems;
 import org.folio.edge.orders.utils.OrdersOkapiClient;
 import org.folio.edge.orders.utils.OrdersOkapiClientFactory;
-
+import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
 
 public class ValidateHandler extends OrdersHandler {
@@ -26,7 +26,22 @@ public class ValidateHandler extends OrdersHandler {
         (client, params) -> {
           PurchasingSystems ps = PurchasingSystems.fromValue(params.get(PARAM_TYPE));
           logger.info("Request is from purchasing system: " + ps.toString());
-          ((OrdersOkapiClient) client).validate(
+          ((OrdersOkapiClient) client).validate(HttpMethod.GET,
+              ps,
+              ctx.request().headers(),
+              resp -> handleProxyResponse(ps, ctx, resp),
+              t -> handleProxyException(ctx, t));
+        });
+  }
+
+  protected void handlePost(RoutingContext ctx) {
+    handleCommon(ctx,
+        new String[] {},
+        new String[] {},
+        (client, params) -> {
+          PurchasingSystems ps = PurchasingSystems.fromValue(params.get(PARAM_TYPE));
+          logger.info("Request is from purchasing system: " + ps.toString());
+          ((OrdersOkapiClient) client).validate(HttpMethod.POST,
               ps,
               ctx.request().headers(),
               resp -> handleProxyResponse(ps, ctx, resp),

--- a/src/main/java/org/folio/edge/orders/ValidateHandler.java
+++ b/src/main/java/org/folio/edge/orders/ValidateHandler.java
@@ -2,13 +2,12 @@ package org.folio.edge.orders;
 
 import static org.folio.edge.orders.Constants.PARAM_TYPE;
 
+import io.vertx.ext.web.RoutingContext;
 import org.apache.log4j.Logger;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.orders.Constants.PurchasingSystems;
 import org.folio.edge.orders.utils.OrdersOkapiClient;
 import org.folio.edge.orders.utils.OrdersOkapiClientFactory;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.RoutingContext;
 
 public class ValidateHandler extends OrdersHandler {
 
@@ -26,22 +25,7 @@ public class ValidateHandler extends OrdersHandler {
         (client, params) -> {
           PurchasingSystems ps = PurchasingSystems.fromValue(params.get(PARAM_TYPE));
           logger.info("Request is from purchasing system: " + ps.toString());
-          ((OrdersOkapiClient) client).validate(HttpMethod.GET,
-              ps,
-              ctx.request().headers(),
-              resp -> handleProxyResponse(ps, ctx, resp),
-              t -> handleProxyException(ctx, t));
-        });
-  }
-
-  protected void handlePost(RoutingContext ctx) {
-    handleCommon(ctx,
-        new String[] {},
-        new String[] {},
-        (client, params) -> {
-          PurchasingSystems ps = PurchasingSystems.fromValue(params.get(PARAM_TYPE));
-          logger.info("Request is from purchasing system: " + ps.toString());
-          ((OrdersOkapiClient) client).validate(HttpMethod.POST,
+          ((OrdersOkapiClient) client).validate(ctx.request().method(),
               ps,
               ctx.request().headers(),
               resp -> handleProxyResponse(ps, ctx, resp),

--- a/src/main/java/org/folio/edge/orders/utils/OrdersOkapiClient.java
+++ b/src/main/java/org/folio/edge/orders/utils/OrdersOkapiClient.java
@@ -11,6 +11,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
 
 public class OrdersOkapiClient extends OkapiClient {
 
@@ -28,10 +29,10 @@ public class OrdersOkapiClient extends OkapiClient {
     defaultHeaders.set(HttpHeaders.ACCEPT, XML_OR_TEXT);
   }
 
-  public void validate(PurchasingSystems ps, MultiMap headers, Handler<HttpClientResponse> responseHandler,
+  public void validate(HttpMethod method, PurchasingSystems ps, MultiMap headers, Handler<HttpClientResponse> responseHandler,
       Handler<Throwable> exceptionHandler) {
     if (PurchasingSystems.GOBI == ps) {
-      validateGobi(headers, responseHandler, exceptionHandler);
+      validateGobi(method, headers, responseHandler, exceptionHandler);
     } else {
       exceptionHandler
         .handle(new NotImplementedException("validate(...) for " + ps + " is not supported yet"));
@@ -64,18 +65,22 @@ public class OrdersOkapiClient extends OkapiClient {
         exceptionHandler);
   }
 
-  public void validateGobi(Handler<HttpClientResponse> responseHandler,
+  public void validateGobi(HttpMethod method, MultiMap headers, Handler<HttpClientResponse> responseHandler,
       Handler<Throwable> exceptionHandler) {
-    validateGobi(null, responseHandler, exceptionHandler);
-  }
-
-  public void validateGobi(MultiMap headers, Handler<HttpClientResponse> responseHandler,
-      Handler<Throwable> exceptionHandler) {
-    get(
+    if(HttpMethod.GET.equals(method))
+     get(
         String.format("%s/gobi/validate", okapiURL),
         tenant,
         combineHeadersWithDefaults(headers),
         responseHandler,
         exceptionHandler);
+    else
+      post(
+          String.format("%s/gobi/validate", okapiURL),
+          null,
+          tenant,
+          combineHeadersWithDefaults(headers),
+          responseHandler,
+          exceptionHandler);
   }
 }

--- a/src/main/java/org/folio/edge/orders/utils/OrdersOkapiClient.java
+++ b/src/main/java/org/folio/edge/orders/utils/OrdersOkapiClient.java
@@ -67,14 +67,15 @@ public class OrdersOkapiClient extends OkapiClient {
 
   public void validateGobi(HttpMethod method, MultiMap headers, Handler<HttpClientResponse> responseHandler,
       Handler<Throwable> exceptionHandler) {
-    if(HttpMethod.GET.equals(method))
+    if(HttpMethod.GET.equals(method)) {
      get(
         String.format("%s/gobi/validate", okapiURL),
         tenant,
         combineHeadersWithDefaults(headers),
         responseHandler,
         exceptionHandler);
-    else
+    }
+    else {
       post(
           String.format("%s/gobi/validate", okapiURL),
           null,
@@ -82,5 +83,6 @@ public class OrdersOkapiClient extends OkapiClient {
           combineHeadersWithDefaults(headers),
           responseHandler,
           exceptionHandler);
+    }
   }
 }

--- a/src/test/java/org/folio/edge/orders/utils/OrdersMockOkapi.java
+++ b/src/test/java/org/folio/edge/orders/utils/OrdersMockOkapi.java
@@ -38,8 +38,7 @@ public class OrdersMockOkapi extends MockOkapi {
   @Override
   public Router defineRoutes() {
     Router router = super.defineRoutes();
-    router.route(HttpMethod.GET, "/gobi/validate").handler(this::validateHandler);
-    router.route(HttpMethod.POST, "/gobi/validate").handler(this::validateHandler);
+    router.route(HttpMethod.GET, "/gobi/validate").method(HttpMethod.POST).handler(this::validateHandler);
     router.route(HttpMethod.POST, "/gobi/orders").handler(this::placeOrdersHandler);
     return router;
   }
@@ -59,16 +58,18 @@ public class OrdersMockOkapi extends MockOkapi {
           .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
           .end("No suitable module found for path /gobi/validate");
     } else {
-      if (ctx.request().method().equals(HttpMethod.GET))
+      if (ctx.request().method().equals(HttpMethod.GET)) {
         ctx.response()
             .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_XML)
             .setStatusCode(200)
             .end("<test>GET - OK</test>");
-      else
+      }
+      else {
         ctx.response()
             .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_XML)
             .setStatusCode(200)
             .end("<test>POST - OK</test>");
+      }
     }
   }
 

--- a/src/test/java/org/folio/edge/orders/utils/OrdersMockOkapi.java
+++ b/src/test/java/org/folio/edge/orders/utils/OrdersMockOkapi.java
@@ -39,6 +39,7 @@ public class OrdersMockOkapi extends MockOkapi {
   public Router defineRoutes() {
     Router router = super.defineRoutes();
     router.route(HttpMethod.GET, "/gobi/validate").handler(this::validateHandler);
+    router.route(HttpMethod.POST, "/gobi/validate").handler(this::postValidateHandler);
     router.route(HttpMethod.POST, "/gobi/orders").handler(this::placeOrdersHandler);
     return router;
   }
@@ -60,8 +61,32 @@ public class OrdersMockOkapi extends MockOkapi {
     } else {
 
       ctx.response()
-        .setStatusCode(204)
-        .end();
+        .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_XML)
+        .setStatusCode(200)
+        .end("<test>GET - OK</test>");
+    }
+  }
+
+  public void postValidateHandler(RoutingContext ctx) {
+    String token = ctx.request().getHeader(X_OKAPI_TOKEN);
+    String status = ctx.request().getHeader(X_ECHO_STATUS);
+
+    if (token == null || !token.equals(MOCK_TOKEN)) {
+      ctx.response()
+        .setStatusCode(403)
+        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+        .end("Access requires permission: gobi.order.post");
+    } else if (status != null && !status.isEmpty()) {
+      ctx.response()
+        .setStatusCode(Integer.valueOf(status))
+        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+        .end("No suitable module found for path /gobi/validate");
+    } else {
+
+      ctx.response()
+        .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_XML)
+        .setStatusCode(200)
+        .end("<test>POST - OK</test>");
     }
   }
 
@@ -115,6 +140,7 @@ public class OrdersMockOkapi extends MockOkapi {
       return Mappers.XML_PROLOG + "<Response><PoLineNumber>" + id + "</PoLineNumber></Response>";
     }
   }
+
 
   public static String getGobiOrderAsJson(String id) {
     try {

--- a/src/test/java/org/folio/edge/orders/utils/OrdersMockOkapi.java
+++ b/src/test/java/org/folio/edge/orders/utils/OrdersMockOkapi.java
@@ -39,7 +39,7 @@ public class OrdersMockOkapi extends MockOkapi {
   public Router defineRoutes() {
     Router router = super.defineRoutes();
     router.route(HttpMethod.GET, "/gobi/validate").handler(this::validateHandler);
-    router.route(HttpMethod.POST, "/gobi/validate").handler(this::postValidateHandler);
+    router.route(HttpMethod.POST, "/gobi/validate").handler(this::validateHandler);
     router.route(HttpMethod.POST, "/gobi/orders").handler(this::placeOrdersHandler);
     return router;
   }
@@ -50,43 +50,25 @@ public class OrdersMockOkapi extends MockOkapi {
 
     if (token == null || !token.equals(MOCK_TOKEN)) {
       ctx.response()
-        .setStatusCode(403)
-        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .end("Access requires permission: gobi.order.post");
+          .setStatusCode(403)
+          .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+          .end("Access requires permission: gobi.order.post");
     } else if (status != null && !status.isEmpty()) {
       ctx.response()
-        .setStatusCode(Integer.valueOf(status))
-        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .end("No suitable module found for path /gobi/validate");
+          .setStatusCode(Integer.valueOf(status))
+          .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+          .end("No suitable module found for path /gobi/validate");
     } else {
-
-      ctx.response()
-        .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_XML)
-        .setStatusCode(200)
-        .end("<test>GET - OK</test>");
-    }
-  }
-
-  public void postValidateHandler(RoutingContext ctx) {
-    String token = ctx.request().getHeader(X_OKAPI_TOKEN);
-    String status = ctx.request().getHeader(X_ECHO_STATUS);
-
-    if (token == null || !token.equals(MOCK_TOKEN)) {
-      ctx.response()
-        .setStatusCode(403)
-        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .end("Access requires permission: gobi.order.post");
-    } else if (status != null && !status.isEmpty()) {
-      ctx.response()
-        .setStatusCode(Integer.valueOf(status))
-        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .end("No suitable module found for path /gobi/validate");
-    } else {
-
-      ctx.response()
-        .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_XML)
-        .setStatusCode(200)
-        .end("<test>POST - OK</test>");
+      if (ctx.request().method().equals(HttpMethod.GET))
+        ctx.response()
+            .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_XML)
+            .setStatusCode(200)
+            .end("<test>GET - OK</test>");
+      else
+        ctx.response()
+            .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_XML)
+            .setStatusCode(200)
+            .end("<test>POST - OK</test>");
     }
   }
 

--- a/src/test/java/org/folio/edge/orders/utils/OrdersOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/orders/utils/OrdersOkapiClientTest.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -76,21 +77,43 @@ public class OrdersOkapiClientTest {
   @After
   public void tearDown(TestContext context) {
     client.close();
-    mockOkapi.close();
+    mockOkapi.close(context);
   }
 
   @Test
-  public void testValidateGobiSuccess(TestContext context) {
-    logger.info("=== Test successful validate ===");
+  public void testValidateGetGobiSuccess(TestContext context) {
+    logger.info("=== Test successful GET validate ===");
 
     Async async = context.async();
     client.login("admin", "password").thenAcceptAsync(v -> {
       // Redundant - also checked in testLogin(...), but can't hurt
       context.assertEquals(MOCK_TOKEN, client.getToken());
 
-      client.validateGobi(
+      client.validateGobi(HttpMethod.GET,
+          null,
           resp -> {
-            context.assertEquals(204, resp.statusCode());
+            context.assertEquals(200, resp.statusCode());
+            async.complete();
+          },
+          t -> {
+            context.fail(t.getMessage());
+          });
+    });
+  }
+
+  @Test
+  public void testValidatePostGobiSuccess(TestContext context) {
+    logger.info("=== Test successful POST validate ===");
+
+    Async async = context.async();
+    client.login("admin", "password").thenAcceptAsync(v -> {
+      // Redundant - also checked in testLogin(...), but can't hurt
+      context.assertEquals(MOCK_TOKEN, client.getToken());
+
+      client.validateGobi(HttpMethod.POST,
+          null,
+          resp -> {
+            context.assertEquals(200, resp.statusCode());
             async.complete();
           },
           t -> {
@@ -101,7 +124,7 @@ public class OrdersOkapiClientTest {
 
   @Test
   public void testValidateUnsupportedPurchasingSystem(TestContext context) {
-    logger.info("=== Test successful validate ===");
+    logger.info("=== Test successful GET validate ===");
 
     Async async = context.async();
     client.login("admin", "password").thenAcceptAsync(v -> {
@@ -109,6 +132,7 @@ public class OrdersOkapiClientTest {
       context.assertEquals(MOCK_TOKEN, client.getToken());
 
       client.validate(
+          HttpMethod.GET,
           null,
           null,
           resp -> {


### PR DESCRIPTION
## PURPOSE
https://issues.folio.org/browse/EDGORDERS-9
https://issues.folio.org/browse/EDGORDERS-10
https://issues.folio.org/browse/EDGORDERS-11
https://issues.folio.org/browse/EDGORDERS-12

## APPROACH
Added new API to support the POST for GOBI API validation and changed the response code to 200, to be in sync with mod-gobi
Upgraded the RAMl to 1.0  

