### PR TITLE
Handling the Encoding header

### DIFF
--- a/src/main/java/org/folio/edge/orders/OrdersHandler.java
+++ b/src/main/java/org/folio/edge/orders/OrdersHandler.java
@@ -38,6 +38,11 @@ public class OrdersHandler extends Handler {
   protected void handleCommon(RoutingContext ctx, String[] requiredParams, String[] optionalParams,
       TwoParamVoidFunction<OkapiClient, Map<String, String>> action) {
 
+    // the responses are short, we can safely drop the encoding header if passed
+    if (null != ctx.request().getHeader(HttpHeaders.ACCEPT_ENCODING)) {
+      ctx.request().headers().remove(HttpHeaders.ACCEPT_ENCODING);
+    }
+
     String type = ctx.request()
         .getParam(PARAM_TYPE);
     if (type == null || type.isEmpty()) {

--- a/src/main/java/org/folio/edge/orders/ValidateHandler.java
+++ b/src/main/java/org/folio/edge/orders/ValidateHandler.java
@@ -3,7 +3,6 @@ package org.folio.edge.orders;
 import static org.folio.edge.orders.Constants.PARAM_TYPE;
 
 import io.vertx.ext.web.RoutingContext;
-import org.apache.http.HttpHeaders;
 import org.apache.log4j.Logger;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.orders.Constants.PurchasingSystems;
@@ -28,8 +27,7 @@ public class ValidateHandler extends OrdersHandler {
           logger.info("Request is from purchasing system: " + ps.toString());
           ((OrdersOkapiClient) client).validate(ctx.request().method(),
               ps,
-              // the responses are short, we can safely drop the encoding header if passed
-              ctx.request().headers().remove(HttpHeaders.ACCEPT_ENCODING),
+              ctx.request().headers(),
               resp -> handleProxyResponse(ps, ctx, resp),
               t -> handleProxyException(ctx, t));
         });

--- a/src/main/java/org/folio/edge/orders/ValidateHandler.java
+++ b/src/main/java/org/folio/edge/orders/ValidateHandler.java
@@ -3,6 +3,7 @@ package org.folio.edge.orders;
 import static org.folio.edge.orders.Constants.PARAM_TYPE;
 
 import io.vertx.ext.web.RoutingContext;
+import org.apache.http.HttpHeaders;
 import org.apache.log4j.Logger;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.orders.Constants.PurchasingSystems;
@@ -27,7 +28,8 @@ public class ValidateHandler extends OrdersHandler {
           logger.info("Request is from purchasing system: " + ps.toString());
           ((OrdersOkapiClient) client).validate(ctx.request().method(),
               ps,
-              ctx.request().headers(),
+              // the responses are short, we can safely drop the encoding header if passed
+              ctx.request().headers().remove(HttpHeaders.ACCEPT_ENCODING),
               resp -> handleProxyResponse(ps, ctx, resp),
               t -> handleProxyException(ctx, t));
         });

--- a/src/test/java/org/folio/edge/orders/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/orders/MainVerticleTest.java
@@ -45,6 +45,7 @@ import org.junit.runner.RunWith;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.response.Header;
 import com.jayway.restassured.response.Response;
 
 import io.vertx.core.DeploymentOptions;
@@ -150,6 +151,20 @@ public class MainVerticleTest {
     logger.info("=== Test GET validate w/ valid key ===");
 
     RestAssured
+      .get("/orders/validate?type=GOBI&apiKey=" + apiKey)
+      .then()
+      .statusCode(200)
+      .assertThat()
+      .body(containsString("<test>GET - OK</test>"));
+  }
+
+  @Test
+  public void testGetValidateSuccessWithEncoding(TestContext context) {
+    logger.info("=== Test GET validate w/ valid key and Accept Encoding header===");
+
+    RestAssured
+      .with()
+      .header(new Header(HttpHeaders.ACCEPT_ENCODING, "gzip deflate"))
       .get("/orders/validate?type=GOBI&apiKey=" + apiKey)
       .then()
       .statusCode(200)


### PR DESCRIPTION
https://issues.folio.org/browse/EDGORDERS-10

## PURPOSE
If the request is send with an Accept Endoding header, the response fails with internal server error, failed to convert response

## APPROACH
As the payload sent from mod-gobi is pretty small, we will not need any compression. Hence dropping the header if it is passed.