### PR TITLE
EDGORDERS-15: Ignore request body on POST /orders/validate

### DIFF
--- a/src/main/java/org/folio/edge/orders/ValidateHandler.java
+++ b/src/main/java/org/folio/edge/orders/ValidateHandler.java
@@ -11,6 +11,7 @@ import org.folio.edge.orders.utils.OrdersOkapiClientFactory;
 
 public class ValidateHandler extends OrdersHandler {
 
+	private static final String CONTENT_LENGTH_ZERO = "0";
   private static final Logger logger = Logger.getLogger(ValidateHandler.class);
 
   public ValidateHandler(SecureStore secureStore, OrdersOkapiClientFactory ocf) {
@@ -25,6 +26,9 @@ public class ValidateHandler extends OrdersHandler {
         (client, params) -> {
           PurchasingSystems ps = PurchasingSystems.fromValue(params.get(PARAM_TYPE));
           logger.info("Request is from purchasing system: " + ps.toString());
+
+          // EDGORDERS-15: Set request header content-length to zero to ignore processing body
+          ctx.request().headers().set("Content-Length", CONTENT_LENGTH_ZERO);
           ((OrdersOkapiClient) client).validate(ctx.request().method(),
               ps,
               ctx.request().headers(),

--- a/src/test/java/org/folio/edge/orders/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/orders/MainVerticleTest.java
@@ -173,6 +173,23 @@ public class MainVerticleTest {
   }
 
   @Test
+  public void testPostValidateSuccessIgnoreBody(TestContext context) {
+  	// EDGORDERS-15 - Ignore processing request body
+    logger.info("=== Test POST validate w/ valid key and ignore processing request body ===");
+
+    String PO = "118279";
+    String body = mockRequests.get(PO);
+    
+    RestAssured
+    .with().body(body)
+      .post("/orders/validate?type=GOBI&apiKey=" + apiKey)
+      .then()
+      .statusCode(200)
+      .assertThat()
+      .body(containsString("<test>POST - OK</test>"));
+  }
+  
+  @Test
   public void testPostValidateSuccess(TestContext context) {
     logger.info("=== Test POST validate w/ valid key ===");
 


### PR DESCRIPTION
## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/EDGORDERS-15

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Set request body content-length to zero to ignore, if any.
- Add unit test
