### PR TITLE
EDGORDERS-63: edge-common 4.4.1 fixing disabled SSL in Vert.x WebClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.3.1</version>
+        <version>4.3.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.3.0</version>
+      <version>4.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/test/java/org/folio/edge/orders/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/orders/MainVerticleTest.java
@@ -18,9 +18,7 @@ import static org.folio.edge.orders.utils.OrdersMockOkapi.BODY_REQUEST_FOR_HEADE
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
 
 import java.io.File;
@@ -86,7 +84,7 @@ public class MainVerticleTest {
     knownTenants.add(ApiKeyUtils.parseApiKey(apiKey).tenantId);
 
     mockOkapi = spy(new OrdersMockOkapi(okapiPort, knownTenants));
-    mockOkapi.start(context);
+    mockOkapi.start().onComplete(context.asyncAssertSuccess());
 
     vertx = Vertx.vertx();
     System.setProperty(SYS_PORT, String.valueOf(serverPort));
@@ -125,17 +123,7 @@ public class MainVerticleTest {
   @AfterClass
   public static void tearDownOnce(TestContext context) {
     logger.info("Shutting down server");
-    vertx.close(res -> {
-      if (res.failed()) {
-        logger.error("Failed to shut down edge-orders server", res.cause());
-        fail(res.cause().getMessage());
-      } else {
-        logger.info("Successfully shut down edge-orders server");
-      }
-
-      logger.info("Shutting down mock Okapi");
-      mockOkapi.close(context);
-    });
+    mockOkapi.close().onComplete(context.asyncAssertSuccess());
   }
 
   @Test

--- a/src/test/java/org/folio/edge/orders/utils/OrdersOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/orders/utils/OrdersOkapiClientTest.java
@@ -2,7 +2,6 @@ package org.folio.edge.orders.utils;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -49,7 +48,7 @@ public class OrdersOkapiClientTest {
     knownTenants.add(tenant);
 
     mockOkapi = new OrdersMockOkapi(okapiPort, knownTenants);
-    mockOkapi.start(context);
+    mockOkapi.start().onComplete(context.asyncAssertSuccess());
 
     client = new OrdersOkapiClientFactory(Vertx.vertx(),
         "http://localhost:" + okapiPort, reqTimeout)
@@ -77,7 +76,7 @@ public class OrdersOkapiClientTest {
   @After
   public void tearDown(TestContext context) {
     client.client.close();
-    mockOkapi.close(context);
+    mockOkapi.close().onComplete(context.asyncAssertSuccess());
   }
 
   @Test


### PR DESCRIPTION
Upgrade edge-common from 4.3.0 to 4.4.1.

This upgrades Vert.x from 4.3.1 to 4.3.3 fixing disabled SSL in WebClient:
https://github.com/vert-x3/wiki/wiki/4.3.2-Release-Notes#vertx-web

Upgrade vertx-stack-depchain from 4.3.1 to 4.3.3 to keep it in sync with the Vert.x version from edge-common.