### PR TITLE
EDGORDERS-72: Patch Jackson, Vert.x, Aws and Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM folioci/alpine-jre-openjdk11:latest
 
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
+
 ENV VERTICLE_FILE edge-orders-fat.jar
 
 # Set the location of the verticles

--- a/pom.xml
+++ b/pom.xml
@@ -47,14 +47,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.3.3</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>2.13.2</version>
+        <version>4.3.8</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -105,7 +98,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-ssm</artifactId>
-      <version>1.12.221</version>
+      <version>1.12.426</version>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>


### PR DESCRIPTION
Upgrade Vertx from 4.3.3 to 4.3.8.

This indirectly upgrades jackson from 2.13.2 to 2.14.0. This fixes Denial of Service (DoS):

https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004

Upgrade aws-java-sdk-ssm from 1.12.221 to 1.12.426 to match the jackson version.

Upgrade Alpine packages to automatically get security patches.