### PR TITLE
EDGORDERS-78. Upgrade edge-orders to the new version of edge-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,11 @@
     <exec.mainClass>org.folio.edge.orders.MainVerticle</exec.mainClass>
     <sonar.exclusions>**/models/**.java</sonar.exclusions>
     <sonar.test.exclusions>**/*Test.java</sonar.test.exclusions>
-    <log4j.version>2.17.2</log4j.version>
+    <vertx.version>4.4.6</vertx.version>
+    <log4j.version>2.20.0</log4j.version>
+    <edge-common.version>4.5.2</edge-common.version>
+    <aws.sdk.ssm.version>1.12.562</aws.sdk.ssm.version>
+    <vault.java.driver.version>5.1.0</vault.java.driver.version>
     <argLine />
   </properties>
 
@@ -47,7 +51,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.3.8</version>
+        <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -86,7 +90,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.4.1</version>
+      <version>${edge-common.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -98,7 +102,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-ssm</artifactId>
-      <version>1.12.426</version>
+      <version>${aws.sdk.ssm.version}</version>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
@@ -112,7 +116,7 @@
     <dependency>
       <groupId>com.bettercloud</groupId>
       <artifactId>vault-java-driver</artifactId>
-      <version>3.1.0</version>
+      <version>${vault.java.driver.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/edge/orders/MainVerticle.java
+++ b/src/main/java/org/folio/edge/orders/MainVerticle.java
@@ -8,8 +8,8 @@ import org.folio.edge.core.EdgeVerticleHttp;
 import org.folio.edge.orders.utils.OrdersOkapiClientFactory;
 import org.folio.rest.mappings.model.ApiConfiguration;
 import org.folio.rest.mappings.model.Routing;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -28,7 +28,7 @@ import static org.folio.edge.orders.Constants.API_CONFIGURATION_PROPERTY_NAME;
 
 public class MainVerticle extends EdgeVerticleHttp {
 
-  private static final Logger logger = LoggerFactory.getLogger(MainVerticle.class);
+  private static final Logger logger = LogManager.getLogger(MainVerticle.class);
 
   public MainVerticle() {
     super();

--- a/src/main/java/org/folio/edge/orders/OrdersHandler.java
+++ b/src/main/java/org/folio/edge/orders/OrdersHandler.java
@@ -20,8 +20,8 @@ import org.folio.edge.orders.model.ResponseWrapper;
 import org.folio.edge.orders.utils.OrdersOkapiClient;
 import org.folio.edge.orders.utils.OrdersOkapiClientFactory;
 import org.folio.rest.mappings.model.Routing;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
@@ -29,7 +29,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpResponse;
 
 public class OrdersHandler extends Handler {
-  private static final Logger logger = LoggerFactory.getLogger(OrdersHandler.class);
+  private static final Logger logger = LogManager.getLogger(OrdersHandler.class);
 
   public OrdersHandler(SecureStore secureStore, OrdersOkapiClientFactory ocf) {
     super(secureStore, ocf);

--- a/src/test/java/org/folio/edge/orders/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/orders/MainVerticleTest.java
@@ -38,10 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.edge.core.cache.TokenCache;
-import org.folio.edge.core.model.ClientInfo;
 import org.folio.edge.core.utils.ApiKeyUtils;
-import org.folio.edge.core.utils.ApiKeyUtils.MalformedApiKeyException;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.folio.edge.orders.Constants.ErrorCodes;
 import org.folio.edge.orders.model.ErrorWrapper;
@@ -448,14 +445,11 @@ public class MainVerticleTest {
   }
 
   @Test
-  public void testPlaceOrderTimeout(TestContext context) throws MalformedApiKeyException, JsonProcessingException {
+  public void testPlaceOrderTimeout(TestContext context) throws JsonProcessingException {
     logger.info("=== Test place order - Timeout ===");
 
     String PO = "118279";
     String body = mockRequests.get(PO);
-
-    ClientInfo clientInfo = ApiKeyUtils.parseApiKey(apiKey);
-    TokenCache.getInstance().put(clientInfo.salt, clientInfo.tenantId, clientInfo.username, null);
 
     final Response resp = RestAssured
       .with()


### PR DESCRIPTION
- Use the latest edge-common 4.5.2. OrdersHandler calls super.handleCommon which after upgrading edge-common to 4.5.2 will obtain expiring tokens from the authn/login-with-expiry endpoint.
- Upgrade and use the same dependencies versions as in the latest released edge-common to 4.5.2 [Link](https://github.com/folio-org/edge-common/blob/v4.5.2/pom.xml)