### PR TITLE
EDGORDERS-78. Upgrade to the newest version of edge-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.4.1</version>
+      <version>4.5.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/test/java/org/folio/edge/orders/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/orders/MainVerticleTest.java
@@ -38,10 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.edge.core.cache.TokenCache;
-import org.folio.edge.core.model.ClientInfo;
 import org.folio.edge.core.utils.ApiKeyUtils;
-import org.folio.edge.core.utils.ApiKeyUtils.MalformedApiKeyException;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.folio.edge.orders.Constants.ErrorCodes;
 import org.folio.edge.orders.model.ErrorWrapper;
@@ -448,14 +445,11 @@ public class MainVerticleTest {
   }
 
   @Test
-  public void testPlaceOrderTimeout(TestContext context) throws MalformedApiKeyException, JsonProcessingException {
+  public void testPlaceOrderTimeout(TestContext context) throws JsonProcessingException {
     logger.info("=== Test place order - Timeout ===");
 
     String PO = "118279";
     String body = mockRequests.get(PO);
-
-    ClientInfo clientInfo = ApiKeyUtils.parseApiKey(apiKey);
-    TokenCache.getInstance().put(clientInfo.salt, clientInfo.tenantId, clientInfo.username, null);
 
     final Response resp = RestAssured
       .with()


### PR DESCRIPTION
- Use the latest edge-common 4.5.2. OrdersHandler calls super.handleCommon which after upgrading edge-common to 4.5.2 will obtain expiring tokens from the authn/login-with-expiry endpoint. Will be releases to Poppy as Bug Fix
- The separate PR to increase version to the latest created and will be merged to Quesnelia release, currently it fails because admin/health endpoint fails during docker healthcheck https://github.com/folio-org/edge-orders/pull/67 