### PR TITLE
[EDGORDERS-83-SHADE-FIX]. Add maven shade filters to remove Log4j2Plugins.dat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,14 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>**/Log4j2Plugins.dat</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>


### PR DESCRIPTION
A quick fix to resolve jar log4j2 logging at runtime 
The same appraoch is used in other modules on platform
 
![image](https://github.com/folio-org/edge-orders/assets/25097693/34b8dfc3-ea92-4a33-aea2-810e2923d703)
