### PR TITLE
EDGORDERS-87: Vert.x 4.5.7 - netty-codec-http OOM CVE-2024-29025

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <!--Dependency Management Properties-->
     <log4j.version>2.23.0</log4j.version>
-    <vertx.version>4.5.4</vertx.version>
+    <vertx.version>4.5.7</vertx.version>
 
     <!--Dependency properties-->
     <edge-common.version>4.7.0</edge-common.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGORDERS-87

Upgrade Vert.x from 4.5.4 to 4.5.7.

The Vert.x upgrade indirectly upgrades Netty from 4.1.107.Final to 4.1.108.Final fixing netty-codec-http form POST OOM:

https://github.com/netty/netty/security/advisories/GHSA-5jpm-x58v-624v = CVE-2024-29025