### PR TITLE
bump up edge-common to v4.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <vertx.version>4.5.7</vertx.version>
 
     <!--Dependency properties-->
-    <edge-common.version>4.7.0</edge-common.version>
+    <edge-common.version>4.7.1</edge-common.version>
     <aws.sdk.ssm.version>1.12.676</aws.sdk.ssm.version>
     <vault.java.driver.version>5.1.0</vault.java.driver.version>
     <jjwt.version>0.12.3</jjwt.version>


### PR DESCRIPTION
bump up edge-common to v4.7.1: AwsParamStore to support FIPS-approved crypto modules