### PR TITLE
[EDGORDERS-90] Add correct plugin repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,14 @@
     </repository>
   </repositories>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>folio-nexus</id>
+      <name>FOLIO Maven repository</name>
+      <url>https://repository.folio.org/repository/maven-folio</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <distributionManagement>
     <repository>
       <id>folio-nexus</id>


### PR DESCRIPTION
Fix issue reported by FSE team
```

[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/org/folio/folio-module-descriptor-validator/1.0.0/folio-module-descriptor-validator-1.0.0.pom[WARNING] The POM for org.folio:folio-module-descriptor-validator:jar:1.0.0 is missing, no dependency information available
Downloading from central: https://repo.maven.apache.org/maven2/org/folio/folio-module-descriptor-validator/1.0.0/folio-module-descriptor-validator-1.0.0.jar[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.651 s
[INFO] Finished at: 2024-10-22T18:56:03Z
[INFO] ------------------------------------------------------------------------
[ERROR] Plugin org.folio:folio-module-descriptor-validator:1.0.0 or one of its dependencies could not be resolved: Could not find artifact org.folio:folio-module-descriptor-validator:jar:1.0.0 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
```