### PR TITLE
[MODMO-15]. Update MosaicOrder schema & add more endpoints to edge-orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Institutional users should be granted the following permissions in order to use 
 - `orders.acquisition-methods.collection.get`
 - `organizations.organizations.collection.get`
 - `configuration.entries.collection.get`
+- `inventory-storage.locations.collection.get`
+- `inventory-storage.material-types.collection.get`
+- `users.collection.get`
 
 ## Configuration
 

--- a/src/main/java/org/folio/edge/orders/Param.java
+++ b/src/main/java/org/folio/edge/orders/Param.java
@@ -21,4 +21,8 @@ public enum Param {
   public String getDefaultValue() {
     return defaultValue;
   }
+
+  public boolean hasDefaultNonBlankValue() {
+    return !defaultValue.isBlank();
+  }
 }

--- a/src/main/java/org/folio/edge/orders/Param.java
+++ b/src/main/java/org/folio/edge/orders/Param.java
@@ -22,7 +22,7 @@ public enum Param {
     return defaultValue;
   }
 
-  public boolean hasDefaultNonBlankValue() {
+  public boolean isDefaultNonBlankValue() {
     return !defaultValue.isBlank();
   }
 }

--- a/src/main/java/org/folio/edge/orders/QueryUtil.java
+++ b/src/main/java/org/folio/edge/orders/QueryUtil.java
@@ -1,0 +1,78 @@
+package org.folio.edge.orders;
+
+import io.vertx.core.MultiMap;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.rest.mappings.model.Routing;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.folio.edge.orders.Param.QUERY;
+
+public class QueryUtil {
+
+  private QueryUtil() {
+  }
+
+  public static String getRequestMethod(Routing routing) {
+    return routing.getProxyMethod() == null ? routing.getMethod() : routing.getProxyMethod();
+  }
+
+  public static void addOrUpsertExtraQueryString(String extraQuery, MultiMap params) {
+    if (StringUtils.isEmpty(extraQuery)) {
+      return;
+    }
+    if (hasQueryStringPlaceHolder(extraQuery, QUERY) && !params.contains(QUERY.getName())) {
+      params.add(QUERY.getName(), extraQuery);
+    } else {
+      String paramValue = params.get(QUERY.getName());
+      params.set(QUERY.getName(), paramValue.concat(" and ").concat(extraQuery));
+    }
+  }
+
+  public static String getProxyPath(String proxyPath, MultiMap params) {
+    if (Objects.isNull(params)) {
+      return proxyPath;
+    }
+    for (Param param : Param.values()) {
+      if (checkPathHasQueryStringPlaceholderAndValue(proxyPath, params, param)) {
+        proxyPath = param.hasDefaultNonBlankValue() ? setDefaultValue(proxyPath, param) : fullyRemovePlaceholder(proxyPath, param);
+      }
+    }
+    return proxyPath;
+  }
+
+  public static String getResultPath(MultiMap params, String proxyPath) {
+    if (Optional.ofNullable(params).isEmpty()) {
+      return proxyPath;
+    }
+    return QueryUtil.getNormalizedProxyPath(params, proxyPath);
+  }
+
+  public static String getNormalizedProxyPath(MultiMap params, String proxyPath) {
+    return params.names().stream()
+      .reduce(proxyPath, (aggregate, paramKey) -> aggregate.replace(":%s".formatted(paramKey), params.get(paramKey)))
+      .replaceAll("\\s+", "+");
+  }
+
+  private static boolean checkPathHasQueryStringPlaceholderAndValue(String proxyPath, MultiMap params, Param param) {
+    return hasQueryStringPlaceHolder(proxyPath, param) && emptyQueryStringValue(params, param);
+  }
+
+  private static boolean emptyQueryStringValue(MultiMap params, Param param) {
+    return StringUtils.isEmpty(params.get(param.getName()));
+  }
+
+  private static boolean hasQueryStringPlaceHolder(String proxyPath, Param param) {
+    return StringUtils.containsAny(proxyPath, ":%s".formatted(param.getName()));
+  }
+
+  private static String setDefaultValue(String proxyPath, Param param) {
+    return proxyPath.replace(":%s".formatted(param.getName()), param.getDefaultValue());
+  }
+
+  private static String fullyRemovePlaceholder(String proxyPath, Param param) {
+    String placeholderPattern = "(\\?|&)(%1$s=:%1$s)".formatted(param.getName());
+    return proxyPath.replaceAll(placeholderPattern, "");
+  }
+}

--- a/src/main/java/org/folio/edge/orders/QueryUtil.java
+++ b/src/main/java/org/folio/edge/orders/QueryUtil.java
@@ -36,7 +36,7 @@ public class QueryUtil {
     }
     for (Param param : Param.values()) {
       if (checkPathHasQueryStringPlaceholderAndValue(proxyPath, params, param)) {
-        proxyPath = param.hasDefaultNonBlankValue() ? setDefaultValue(proxyPath, param) : fullyRemovePlaceholder(proxyPath, param);
+        proxyPath = param.isDefaultNonBlankValue() ? setDefaultValue(proxyPath, param) : fullyRemovePlaceholder(proxyPath, param);
       }
     }
     return proxyPath;

--- a/src/main/resources/api_configuration.json
+++ b/src/main/resources/api_configuration.json
@@ -113,8 +113,7 @@
       "type": "COMMON",
       "method": "GET",
       "pathPattern": "/users",
-      "proxyPath": "/users?offset=:offset&limit=:limit&query=:query",
-      "extraQuery": "type==staff"
+      "proxyPath": "/users?offset=:offset&limit=:limit&query=:query"
     }
   ]
 }

--- a/src/main/resources/api_configuration.json
+++ b/src/main/resources/api_configuration.json
@@ -100,19 +100,19 @@
     {
       "type": "COMMON",
       "method": "GET",
-      "pathPattern": "/locations-for-orders",
+      "pathPattern": "/locations-for-order",
       "proxyPath": "/locations?offset=:offset&limit=:limit&query=:query"
     },
     {
       "type": "COMMON",
       "method": "GET",
-      "pathPattern": "/material-types-for-orders",
+      "pathPattern": "/material-types-for-order",
       "proxyPath": "/material-types?offset=:offset&limit=:limit&query=:query"
     },
     {
       "type": "COMMON",
       "method": "GET",
-      "pathPattern": "/users-for-orders",
+      "pathPattern": "/users-for-order",
       "proxyPath": "/users?offset=:offset&limit=:limit&query=:query"
     }
   ]

--- a/src/main/resources/api_configuration.json
+++ b/src/main/resources/api_configuration.json
@@ -113,7 +113,8 @@
       "type": "COMMON",
       "method": "GET",
       "pathPattern": "/users",
-      "proxyPath": "/users?offset=:offset&limit=:limit&query=:query"
+      "proxyPath": "/users?offset=:offset&limit=:limit&query=:query",
+      "extraQuery": "type==staff"
     }
   ]
 }

--- a/src/main/resources/api_configuration.json
+++ b/src/main/resources/api_configuration.json
@@ -94,7 +94,26 @@
       "type": "COMMON",
       "method": "GET",
       "pathPattern": "/addresses/billing-and-shipping",
-      "proxyPath": "/configurations/entries?query=configName==tenant.addresses"
+      "proxyPath": "/configurations/entries?offset=:offset&limit=:limit&query=:query",
+      "extraQuery": "configName==tenant.addresses"
+    },
+    {
+      "type": "COMMON",
+      "method": "GET",
+      "pathPattern": "/locations",
+      "proxyPath": "/locations?offset=:offset&limit=:limit&query=:query"
+    },
+    {
+      "type": "COMMON",
+      "method": "GET",
+      "pathPattern": "/material-types",
+      "proxyPath": "/material-types?offset=:offset&limit=:limit&query=:query"
+    },
+    {
+      "type": "COMMON",
+      "method": "GET",
+      "pathPattern": "/users",
+      "proxyPath": "/users?offset=:offset&limit=:limit&query=:query"
     }
   ]
 }

--- a/src/main/resources/api_configuration.json
+++ b/src/main/resources/api_configuration.json
@@ -100,19 +100,19 @@
     {
       "type": "COMMON",
       "method": "GET",
-      "pathPattern": "/locations",
+      "pathPattern": "/locations-for-orders",
       "proxyPath": "/locations?offset=:offset&limit=:limit&query=:query"
     },
     {
       "type": "COMMON",
       "method": "GET",
-      "pathPattern": "/material-types",
+      "pathPattern": "/material-types-for-orders",
       "proxyPath": "/material-types?offset=:offset&limit=:limit&query=:query"
     },
     {
       "type": "COMMON",
       "method": "GET",
-      "pathPattern": "/users",
+      "pathPattern": "/users-for-orders",
       "proxyPath": "/users?offset=:offset&limit=:limit&query=:query"
     }
   ]

--- a/src/main/resources/schema/apiConfiguration.json
+++ b/src/main/resources/schema/apiConfiguration.json
@@ -28,6 +28,10 @@
           "proxyPath": {
             "description": "URI for proxy forwarding",
             "type": "string"
+          },
+          "extraQuery": {
+            "description": "Extra query params to restrict all response from the path",
+            "type": "string"
           }
         },
         "additionalProperties": false,

--- a/src/main/resources/schema/apiConfiguration.json
+++ b/src/main/resources/schema/apiConfiguration.json
@@ -30,7 +30,7 @@
             "type": "string"
           },
           "extraQuery": {
-            "description": "Extra query params to restrict all response from the path",
+            "description": "Extra query predicates to better restrict the proxy path response",
             "type": "string"
           }
         },

--- a/src/test/java/org/folio/edge/orders/CommonEndpoint.java
+++ b/src/test/java/org/folio/edge/orders/CommonEndpoint.java
@@ -16,13 +16,13 @@ public enum CommonEndpoint {
   private final String ingressUrl;
   private final String egressUrl;
   private final String dataKey;
-  private final boolean hasEmptyExtraQuery;
+  private final boolean isEmptyExtraQuery;
 
-  CommonEndpoint(String ingressUrl, String egressUrl, String dataKey, boolean hasEmptyExtraQuery) {
+  CommonEndpoint(String ingressUrl, String egressUrl, String dataKey, boolean isEmptyExtraQuery) {
     this.ingressUrl = ingressUrl;
     this.egressUrl = egressUrl;
     this.dataKey = dataKey;
-    this.hasEmptyExtraQuery = hasEmptyExtraQuery;
+    this.isEmptyExtraQuery = isEmptyExtraQuery;
   }
 
   public String getIngressUrl() {
@@ -38,6 +38,6 @@ public enum CommonEndpoint {
   }
 
   public boolean isEmptyExtraQuery() {
-    return hasEmptyExtraQuery;
+    return isEmptyExtraQuery;
   }
 }

--- a/src/test/java/org/folio/edge/orders/CommonEndpoint.java
+++ b/src/test/java/org/folio/edge/orders/CommonEndpoint.java
@@ -9,9 +9,9 @@ public enum CommonEndpoint {
   ACQUISITIONS_METHODS("/acquisition-methods", "/orders/acquisition-methods", "acquisitionMethods", true),
   ORGANIZATIONS("/organizations", "/organizations/organizations", "organizations", true),
   BILLING_AND_SHIPPING("/addresses/billing-and-shipping", "/configurations/entries", "configs", false),
-  LOCATIONS("/locations-for-orders", "/locations", "locations", true),
-  MATERIAL_TYPES("/material-types-for-orders", "/material-types", "mtypes", true),
-  USERS("/users-for-orders", "/users", "users", true);
+  LOCATIONS("/locations-for-order", "/locations", "locations", true),
+  MATERIAL_TYPES("/material-types-for-order", "/material-types", "mtypes", true),
+  USERS("/users-for-order", "/users", "users", true);
 
   private final String ingressUrl;
   private final String egressUrl;

--- a/src/test/java/org/folio/edge/orders/CommonEndpoint.java
+++ b/src/test/java/org/folio/edge/orders/CommonEndpoint.java
@@ -11,7 +11,7 @@ public enum CommonEndpoint {
   BILLING_AND_SHIPPING("/addresses/billing-and-shipping", "/configurations/entries", "configs", false),
   LOCATIONS("/locations", "/locations", "locations", true),
   MATERIAL_TYPES("/material-types", "/material-types", "mtypes", true),
-  USERS("/users", "/users", "users", false);
+  USERS("/users", "/users", "users", true);
 
   private final String ingressUrl;
   private final String egressUrl;
@@ -37,7 +37,7 @@ public enum CommonEndpoint {
     return dataKey;
   }
 
-  public boolean hasEmptyExtraQuery() {
+  public boolean isEmptyExtraQuery() {
     return hasEmptyExtraQuery;
   }
 }

--- a/src/test/java/org/folio/edge/orders/CommonEndpoint.java
+++ b/src/test/java/org/folio/edge/orders/CommonEndpoint.java
@@ -8,18 +8,21 @@ public enum CommonEndpoint {
   ACQUISITIONS_UNITS("/acquisitions-units", "/acquisitions-units/units", "acquisitionsUnits", true),
   ACQUISITIONS_METHODS("/acquisition-methods", "/orders/acquisition-methods", "acquisitionMethods", true),
   ORGANIZATIONS("/organizations", "/organizations/organizations", "organizations", true),
-  BILLING_AND_SHIPPING("/addresses/billing-and-shipping", "/configurations/entries", "configs", false);
+  BILLING_AND_SHIPPING("/addresses/billing-and-shipping", "/configurations/entries", "configs", false),
+  LOCATIONS("/locations", "/locations", "locations", true),
+  MATERIAL_TYPES("/material-types", "/material-types", "mtypes", true),
+  USERS("/users", "/users", "users", true);
 
   private final String ingressUrl;
   private final String egressUrl;
   private final String dataKey;
-  private final boolean hasFiltering;
+  private final boolean hasEmptyExtraQuery;
 
-  CommonEndpoint(String ingressUrl, String egressUrl, String dataKey, boolean hasFiltering) {
+  CommonEndpoint(String ingressUrl, String egressUrl, String dataKey, boolean hasEmptyExtraQuery) {
     this.ingressUrl = ingressUrl;
     this.egressUrl = egressUrl;
     this.dataKey = dataKey;
-    this.hasFiltering = hasFiltering;
+    this.hasEmptyExtraQuery = hasEmptyExtraQuery;
   }
 
   public String getIngressUrl() {
@@ -34,7 +37,7 @@ public enum CommonEndpoint {
     return dataKey;
   }
 
-  public boolean isHasFiltering() {
-    return hasFiltering;
+  public boolean hasEmptyExtraQuery() {
+    return hasEmptyExtraQuery;
   }
 }

--- a/src/test/java/org/folio/edge/orders/CommonEndpoint.java
+++ b/src/test/java/org/folio/edge/orders/CommonEndpoint.java
@@ -11,7 +11,7 @@ public enum CommonEndpoint {
   BILLING_AND_SHIPPING("/addresses/billing-and-shipping", "/configurations/entries", "configs", false),
   LOCATIONS("/locations", "/locations", "locations", true),
   MATERIAL_TYPES("/material-types", "/material-types", "mtypes", true),
-  USERS("/users", "/users", "users", true);
+  USERS("/users", "/users", "users", false);
 
   private final String ingressUrl;
   private final String egressUrl;

--- a/src/test/java/org/folio/edge/orders/CommonEndpoint.java
+++ b/src/test/java/org/folio/edge/orders/CommonEndpoint.java
@@ -9,9 +9,9 @@ public enum CommonEndpoint {
   ACQUISITIONS_METHODS("/acquisition-methods", "/orders/acquisition-methods", "acquisitionMethods", true),
   ORGANIZATIONS("/organizations", "/organizations/organizations", "organizations", true),
   BILLING_AND_SHIPPING("/addresses/billing-and-shipping", "/configurations/entries", "configs", false),
-  LOCATIONS("/locations", "/locations", "locations", true),
-  MATERIAL_TYPES("/material-types", "/material-types", "mtypes", true),
-  USERS("/users", "/users", "users", true);
+  LOCATIONS("/locations-for-orders", "/locations", "locations", true),
+  MATERIAL_TYPES("/material-types-for-orders", "/material-types", "mtypes", true),
+  USERS("/users-for-orders", "/users", "users", true);
 
   private final String ingressUrl;
   private final String egressUrl;

--- a/src/test/java/org/folio/edge/orders/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/orders/MainVerticleTest.java
@@ -697,7 +697,7 @@ public class MainVerticleTest {
   @Test
   public void testShouldReturnCommonEndpointDataWithOffsetAndLimit() {
     Arrays.stream(CommonEndpoint.values())
-      .filter(CommonEndpoint::hasEmptyExtraQuery)
+      .filter(CommonEndpoint::isEmptyExtraQuery)
       .forEach(endpoint -> {
         logger.info("testShouldReturnCommonEndpointDataWithOffsetAndLimit:: Ingress URL: {}", endpoint.getIngressUrl());
         RestAssured
@@ -713,7 +713,7 @@ public class MainVerticleTest {
   @Test
   public void testShouldReturnCommonEndpointDataWithQuery() {
     Arrays.stream(CommonEndpoint.values())
-      .filter(CommonEndpoint::hasEmptyExtraQuery)
+      .filter(CommonEndpoint::isEmptyExtraQuery)
       .forEach(endpoint -> {
         logger.info("testShouldReturnCommonEndpointDataWithQuery:: Ingress URL: {}", endpoint.getIngressUrl());
         RestAssured
@@ -729,7 +729,7 @@ public class MainVerticleTest {
   @Test
   public void testShouldReturnCommonEndpointDataWithQueryNoData() {
     Arrays.stream(CommonEndpoint.values())
-      .filter(CommonEndpoint::hasEmptyExtraQuery)
+      .filter(CommonEndpoint::isEmptyExtraQuery)
       .forEach(endpoint -> {
         logger.info("testShouldReturnCommonEndpointDataWithQueryNoData:: Ingress URL: {}", endpoint.getIngressUrl());
         RestAssured
@@ -745,7 +745,7 @@ public class MainVerticleTest {
   @Test
   public void testShouldReturnCommonEndpointDataWithEmptyQuery() {
     Arrays.stream(CommonEndpoint.values())
-      .filter(CommonEndpoint::hasEmptyExtraQuery)
+      .filter(CommonEndpoint::isEmptyExtraQuery)
       .forEach(endpoint -> {
         logger.info("testShouldReturnCommonEndpointDataWithEmptyQuery:: Ingress URL: {}", endpoint.getIngressUrl());
         RestAssured

--- a/src/test/java/org/folio/edge/orders/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/orders/MainVerticleTest.java
@@ -697,7 +697,7 @@ public class MainVerticleTest {
   @Test
   public void testShouldReturnCommonEndpointDataWithOffsetAndLimit() {
     Arrays.stream(CommonEndpoint.values())
-      .filter(CommonEndpoint::isHasFiltering)
+      .filter(CommonEndpoint::hasEmptyExtraQuery)
       .forEach(endpoint -> {
         logger.info("testShouldReturnCommonEndpointDataWithOffsetAndLimit:: Ingress URL: {}", endpoint.getIngressUrl());
         RestAssured
@@ -713,7 +713,7 @@ public class MainVerticleTest {
   @Test
   public void testShouldReturnCommonEndpointDataWithQuery() {
     Arrays.stream(CommonEndpoint.values())
-      .filter(CommonEndpoint::isHasFiltering)
+      .filter(CommonEndpoint::hasEmptyExtraQuery)
       .forEach(endpoint -> {
         logger.info("testShouldReturnCommonEndpointDataWithQuery:: Ingress URL: {}", endpoint.getIngressUrl());
         RestAssured
@@ -729,7 +729,7 @@ public class MainVerticleTest {
   @Test
   public void testShouldReturnCommonEndpointDataWithQueryNoData() {
     Arrays.stream(CommonEndpoint.values())
-      .filter(CommonEndpoint::isHasFiltering)
+      .filter(CommonEndpoint::hasEmptyExtraQuery)
       .forEach(endpoint -> {
         logger.info("testShouldReturnCommonEndpointDataWithQueryNoData:: Ingress URL: {}", endpoint.getIngressUrl());
         RestAssured
@@ -745,7 +745,7 @@ public class MainVerticleTest {
   @Test
   public void testShouldReturnCommonEndpointDataWithEmptyQuery() {
     Arrays.stream(CommonEndpoint.values())
-      .filter(CommonEndpoint::isHasFiltering)
+      .filter(CommonEndpoint::hasEmptyExtraQuery)
       .forEach(endpoint -> {
         logger.info("testShouldReturnCommonEndpointDataWithEmptyQuery:: Ingress URL: {}", endpoint.getIngressUrl());
         RestAssured

--- a/src/test/java/org/folio/edge/orders/QueryUtilTest.java
+++ b/src/test/java/org/folio/edge/orders/QueryUtilTest.java
@@ -1,0 +1,235 @@
+package org.folio.edge.orders;
+
+import static org.folio.edge.orders.Param.LIMIT;
+import static org.folio.edge.orders.Param.OFFSET;
+import static org.folio.edge.orders.Param.QUERY;
+import static org.junit.Assert.*;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import org.folio.rest.mappings.model.Routing;
+import org.junit.Test;
+
+public class QueryUtilTest {
+
+  // getRequestMethod
+
+  @Test
+  public void testGetRequestMethod_withProxyMethod() {
+    var routing = new Routing();
+    routing.setMethod("GET");
+    routing.setProxyMethod("POST");
+    var result = QueryUtil.getRequestMethod(routing);
+    assertEquals("POST", result);
+  }
+
+  @Test
+  public void testGetRequestMethod_withoutProxyMethod() {
+    var routing = new Routing();
+    routing.setMethod("GET");
+    routing.setProxyMethod(null);
+    var result = QueryUtil.getRequestMethod(routing);
+    assertEquals("GET", result);
+  }
+
+  // addOrUpsertExtraQueryString
+
+  @Test
+  public void testAddOrUpsertExtraQueryString_withEmptyExtraQuery() {
+    var params = HeadersMultiMap.headers();
+    QueryUtil.addOrUpsertExtraQueryString("", params);
+    assertTrue(params.isEmpty());
+  }
+
+  @Test
+  public void testAddOrUpsertExtraQueryString_withNoExistingQuery() {
+    var params = HeadersMultiMap.headers();
+    var extraQuery = "status=active";
+    QueryUtil.addOrUpsertExtraQueryString(extraQuery, params);
+    assertEquals(extraQuery, params.get(QUERY.getName()));
+  }
+
+  @Test
+  public void testAddOrUpsertExtraQueryString_withExistingQuery() {
+    var params = HeadersMultiMap.headers();
+    params.add(QUERY.getName(), "name=book");
+    var extraQuery = "status=active";
+    QueryUtil.addOrUpsertExtraQueryString(extraQuery, params);
+    assertEquals("name=book and status=active", params.get(QUERY.getName()));
+  }
+
+  // getResultPath
+
+  @Test
+  public void testGetResultPath_withNullParams() {
+    var proxyPath = "/orders/:orderId";
+    var result = QueryUtil.getResultPath(null, proxyPath);
+    assertEquals(proxyPath, result);
+  }
+
+  @Test
+  public void testGetResultPath_withParams() {
+    var params = HeadersMultiMap.headers();
+    params.add("orderId", "123456");
+    var proxyPath = "/orders/:orderId";
+    var result = QueryUtil.getResultPath(params, proxyPath);
+    assertEquals("/orders/123456", result);
+  }
+
+  @Test
+  public void testGetResultPath_withOffsetParam() {
+    var params = HeadersMultiMap.headers();
+    params.add(OFFSET.getName(), "20");
+    var proxyPath = "/orders?offset=:offset";
+    var result = QueryUtil.getResultPath(params, proxyPath);
+    assertEquals("/orders?offset=20", result);
+  }
+
+  @Test
+  public void testGetResultPath_withLimitParam() {
+    var params = HeadersMultiMap.headers();
+    params.add(LIMIT.getName(), "10");
+    var proxyPath = "/orders?limit=:limit";
+    var result = QueryUtil.getResultPath(params, proxyPath);
+    assertEquals("/orders?limit=10", result);
+  }
+
+  @Test
+  public void testGetResultPath_withQueryParam() {
+    var params = HeadersMultiMap.headers();
+    params.add(QUERY.getName(), "title=test");
+    var proxyPath = "/orders?query=:query";
+    var result = QueryUtil.getResultPath(params, proxyPath);
+    assertEquals("/orders?query=title=test", result);
+  }
+
+  @Test
+  public void testGetResultPath_withMultipleQueryParams() {
+    var params = HeadersMultiMap.headers();
+    params.add(OFFSET.getName(), "20");
+    params.add(LIMIT.getName(), "10");
+    params.add(QUERY.getName(), "title=test");
+    var proxyPath = "/orders?offset=:offset&limit=:limit&query=:query";
+    var result = QueryUtil.getResultPath(params, proxyPath);
+    assertEquals("/orders?offset=20&limit=10&query=title=test", result);
+  }
+
+  @Test
+  public void testGetResultPath_withEmptyParamValues() {
+    var params = HeadersMultiMap.headers();
+    params.add(OFFSET.getName(), "");
+    params.add(LIMIT.getName(), "");
+    params.add(QUERY.getName(), "");
+    var proxyPath = "/orders?offset=:offset&limit=:limit&query=:query";
+    var result = QueryUtil.getResultPath(params, proxyPath);
+    assertEquals("/orders?offset=&limit=&query=", result);
+  }
+
+  @Test
+  public void testGetResultPath_withParamsNotInPath() {
+    var params = HeadersMultiMap.headers();
+    params.add(OFFSET.getName(), "20");
+    params.add(LIMIT.getName(), "10");
+    var proxyPath = "/orders/search";
+    var result = QueryUtil.getResultPath(params, proxyPath);
+    assertEquals("/orders/search", result);
+  }
+
+  // getNormalizedProxyPath
+
+  @Test
+  public void testGetNormalizedProxyPath_withSingleParam() {
+    var params = HeadersMultiMap.headers();
+    params.add("orderId", "123456");
+    var proxyPath = "/orders/:orderId";
+    var result = QueryUtil.getNormalizedProxyPath(params, proxyPath);
+    assertEquals("/orders/123456", result);
+  }
+
+  @Test
+  public void testGetNormalizedProxyPath_withMultipleParams() {
+    var params = HeadersMultiMap.headers();
+    params.add("orderId", "123456");
+    params.add("lineId", "789012");
+    var proxyPath = "/orders/:orderId/lines/:lineId";
+    var result = QueryUtil.getNormalizedProxyPath(params, proxyPath);
+    assertEquals("/orders/123456/lines/789012", result);
+  }
+
+  @Test
+  public void testGetNormalizedProxyPath_withSpacesInParam() {
+    var params = HeadersMultiMap.headers();
+    params.add("query", "title contains Books");
+    var proxyPath = "/orders?query=:query";
+    var result = QueryUtil.getNormalizedProxyPath(params, proxyPath);
+    assertEquals("/orders?query=title+contains+Books", result);
+  }
+
+  // getProxyPath
+
+  @Test
+  public void testGetProxyPath_withNullParams() {
+    var proxyPath = "/orders/:orderId";
+    var result = QueryUtil.getProxyPath(proxyPath, null);
+    assertEquals(proxyPath, result);
+  }
+
+  @Test
+  public void testGetProxyPath_withDefaultValue() {
+    var params = HeadersMultiMap.headers();
+    var proxyPath = "/orders?limit=:limit";
+    var result = QueryUtil.getProxyPath(proxyPath, params);
+    assertEquals("/orders?limit=" + LIMIT.getDefaultValue(), result);
+  }
+
+  @Test
+  public void testGetProxyPath_withoutDefaultValue() {
+    var params = HeadersMultiMap.headers();
+    var proxyPath = "/orders?query=:query";
+    var result = QueryUtil.getProxyPath(proxyPath, params);
+    assertEquals("/orders", result);
+  }
+
+  @Test
+  public void testGetProxyPath_withPlaceholderAndValue() {
+    var params = HeadersMultiMap.headers();
+    params.add(LIMIT.getName(), "10");
+    var proxyPath = "/orders?limit=:limit";
+    var result = QueryUtil.getProxyPath(proxyPath, params);
+    assertEquals("/orders?limit=:limit", result);
+  }
+
+  @Test
+  public void testGetProxyPath_withoutPlaceholder() {
+    var params = HeadersMultiMap.headers();
+    var proxyPath = "/orders?status=active";
+    var result = QueryUtil.getProxyPath(proxyPath, params);
+    assertEquals("/orders?status=active", result);
+  }
+
+  @Test
+  public void testGetProxyPath_withEmptyString() {
+    var params = HeadersMultiMap.headers();
+    params.add(QUERY.getName(), "");
+    var proxyPath = "/orders?query=:query";
+    var result = QueryUtil.getProxyPath(proxyPath, params);
+    assertEquals("/orders", result);
+  }
+
+  //
+  @Test
+  public void testGetProxyPath_withNonEmptyString() {
+    var params = HeadersMultiMap.headers();
+    params.add(QUERY.getName(), "value");
+    var proxyPath = "/orders?query=:query";
+    var result = QueryUtil.getProxyPath(proxyPath, params);
+    assertEquals("/orders?query=:query", result);
+  }
+
+  @Test
+  public void testGetProxyPath_multipleParams() {
+    var params = HeadersMultiMap.headers();
+    var proxyPath = "/orders?offset=:offset&limit=:limit&query=:query";
+    var result = QueryUtil.getProxyPath(proxyPath, params);
+    assertEquals("/orders?offset=" + OFFSET.getDefaultValue() +
+      "&limit=" + LIMIT.getDefaultValue(), result);
+  }
+}


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODMO-15>

## Approach

- Add 3 new endpoints (GET /locations, GET /material-types and GET /users)
- Fix issue with CQL query with multiple AND/OR predicates resulting in 400 Bad Request
- Update API Configuration schema to support an Extra Query to be appended to the query construct
- Update unit tests and add new ones covering query string-related methods
- Update README.md with new permissions