### PR TITLE
[MODMO-15-2]. Update module descriptor with 4 new interfaces

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -24,6 +24,10 @@
       "version": "1.0"
     },
     {
+      "id": "custom-fields",
+      "version": "3.0"
+    },
+    {
       "id": "finance.funds",
       "version": "3.0"
     },
@@ -32,24 +36,32 @@
       "version": "3.0"
     },
     {
-      "id": "locations",
-      "version": "3.1"
-    },
-    {
       "id": "acquisitions-units",
       "version": "1.1"
+    },
+    {
+      "id": "acquisition-methods",
+      "version": "1.0"
     },
     {
       "id": "organizations.organizations",
       "version": "1.2"
     },
     {
-      "id": "custom-fields",
-      "version": "3.0"
-    },
-    {
       "id": "configuration",
       "version": "2.0"
+    },
+    {
+      "id": "locations",
+      "version": "3.1"
+    },
+    {
+      "id": "material-types",
+      "version": "2.2"
+    },
+    {
+      "id": "users",
+      "version": "16.4"
     }
   ],
   "permissionSets": [],

--- a/src/test/java/org/folio/edge/orders/QueryUtilTest.java
+++ b/src/test/java/org/folio/edge/orders/QueryUtilTest.java
@@ -214,7 +214,6 @@ public class QueryUtilTest {
     assertEquals("/orders", result);
   }
 
-  //
   @Test
   public void testGetProxyPath_withNonEmptyString() {
     var params = HeadersMultiMap.headers();


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODMO-15>

## Approach

- Add 4 new interfaces: acquisition-methods, locations, material-types and users